### PR TITLE
Add support for FontAwesome 5

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -45,8 +45,8 @@ body {
 }
 
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif;
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace;
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Font Awesome 5 Free", "Glyphicons Halflings", sans-serif;
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Font Awesome 5 Free", "Glyphicons Halflings", monospace;
 }
 
 


### PR DESCRIPTION
## About
The font name for FA5 is slightly different so the plugin was replacing all instances with a square. This simple PR adds the naming for FA5 to resolve that.

# Checklist

- [ ] Wrote documentation on this page
- [x] Formated code


## Impacted Areas in Application
None really. This just prevents the plugin replacing fontawesome 5 in exactly the same way as it does for other icon fonts

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/1296369/99047070-8e1ed800-258b-11eb-8136-ce6b30d3f50b.png)

### After
![after](https://user-images.githubusercontent.com/1296369/99047000-75aebd80-258b-11eb-9b73-5c7703b6fbd9.png)
