### PR TITLE
Add suppor for MSDN (Microsoft docs), Azure DevOps Icons and Trello

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -45,8 +45,8 @@ body {
 }
 
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif;
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace;
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets";
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
 }
 
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -45,8 +45,8 @@ body {
 }
 
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets";
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
 }
 
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -45,8 +45,8 @@ body {
 }
 
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
 }
 
 

--- a/app/styles/core/opendyslexic-bold.css
+++ b/app/styles/core/opendyslexic-bold.css
@@ -7,8 +7,8 @@
   }
 
   :root {
-    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif;
-    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace;
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets";
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
   }
   
   html {

--- a/app/styles/core/opendyslexic-bold.css
+++ b/app/styles/core/opendyslexic-bold.css
@@ -7,8 +7,8 @@
   }
 
   :root {
-    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
-    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
   }
   
   html {

--- a/app/styles/core/opendyslexic-bold.css
+++ b/app/styles/core/opendyslexic-bold.css
@@ -7,8 +7,8 @@
   }
 
   :root {
-    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets";
-    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
   }
   
   html {

--- a/app/styles/core/opendyslexic-italic.css
+++ b/app/styles/core/opendyslexic-italic.css
@@ -6,8 +6,8 @@
   }
 
   :root {
-    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif;
-    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace;
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-seri, docons, "AzureDevOpsMDL2Assets"f;
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
   }
   
   html {

--- a/app/styles/core/opendyslexic-italic.css
+++ b/app/styles/core/opendyslexic-italic.css
@@ -6,8 +6,8 @@
   }
 
   :root {
-    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-seri, docons, "AzureDevOpsMDL2Assets"f;
-    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
   }
   
   html {

--- a/app/styles/core/opendyslexic-italic.css
+++ b/app/styles/core/opendyslexic-italic.css
@@ -6,8 +6,8 @@
   }
 
   :root {
-    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
-    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
   }
   
   html {

--- a/app/styles/core/opendyslexic-regular.css
+++ b/app/styles/core/opendyslexic-regular.css
@@ -29,8 +29,8 @@
   font-style: normal;
 }
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif;
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace;
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets";
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
 }
 
 html {

--- a/app/styles/core/opendyslexic-regular.css
+++ b/app/styles/core/opendyslexic-regular.css
@@ -29,8 +29,8 @@
   font-style: normal;
 }
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets";
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets";
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
 }
 
 html {

--- a/app/styles/core/opendyslexic-regular.css
+++ b/app/styles/core/opendyslexic-regular.css
@@ -29,8 +29,8 @@
   font-style: normal;
 }
 :root {
-  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons;
-  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons;
+  --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, "Glyphicons Halflings", sans-serif, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
+  --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, "Glyphicons Halflings", monospace, docons, "AzureDevOpsMDL2Assets", trellicons, "Material Icons Extended", 'Bol Symbols', Graphik, controlIcons, FontAwesome3;
 }
 
 html {


### PR DESCRIPTION
## About
Both MSDN (Microsoft Developer docs) as well as Azure DevOps use custom fonts for styling icons. These icons were overridden by opendyslexic, which made it quite hard to differentiate between various actions you can do based on "not loaded icons".

(Update 2020-11-25): Trello was also not available for icons, trellicons provides their icons, this has been included as well.

I might have changed a file to much, please let me know if this is the case.

Examples: 
* [] next to the search bar in the docs:
  * https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics?view=netcore-3.1
* [] for all icons in Azure DevOps
  * ![image](https://user-images.githubusercontent.com/1078985/99243294-c7ac4900-2800-11eb-97ef-c7863b992494.png)

# Checklist

- [x] Wrote documentation on this page
- [x] Formatted code

## Impacted Areas in Application
None. Just prevents opendyslexic from replacing icons that it shouldn't.

## Screenshots

**Before**
![image](https://user-images.githubusercontent.com/1078985/99243522-16f27980-2801-11eb-9d3f-abea0c0be56e.png)

**After**
![image](https://user-images.githubusercontent.com/1078985/99243626-3be6ec80-2801-11eb-911d-4d2bdb5546c6.png)

